### PR TITLE
fix: add default dashboard when client url is not set

### DIFF
--- a/app/features/personalInformation/hooks/usePersonalInformationFields.ts
+++ b/app/features/personalInformation/hooks/usePersonalInformationFields.ts
@@ -98,8 +98,10 @@ export function usePersonalInformationFields() {
     schema: birthDateSchema,
     initialValue: (() => {
       if (!data.birthDate) return '';
-      const date = new Date(Number(data.birthDate));
-      return date.toISOString().split('T')[0];
+      const birthDate = new Date(Number(data.birthDate));
+      const [components] = birthDate.toISOString().split('T');
+      const [year, month, date] = components.split('-');
+      return `${month}-${date}-${year}`;
     })(),
   });
 

--- a/app/routes/personal-information.tsx
+++ b/app/routes/personal-information.tsx
@@ -51,10 +51,13 @@ export default function PersonalInformation() {
 
   const redirectUrl = useMemo(() => {
     if (typeof window === 'undefined') return '';
+    if (!oneClickDB.presentationRequest.brand.clientUrl) {
+      return dashboardPageLink;
+    }
 
     const url = new URL(window.location.href);
     const _redirectUrl = new URL(
-      oneClickDB.presentationRequest.brand.clientUrl || ''
+      oneClickDB.presentationRequest.brand.clientUrl
     );
     const optedOut = url.searchParams.get('optedOut');
     const verificationOptions = url.searchParams.get('verificationOptions');


### PR DESCRIPTION
[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work. There should _usually_ be a 1:1 relationship between a ticket and a PR, but that won't always be the case, so you may link the same ticket to multiple PRs, or add additional ticket links to this PR. If there is no ticket, you should probably create one and use the "added after sprint planning" label,
--->

## Summary
Brands that have not set clientUrl and are 1CS non-hosted led to the bad exception. Also, the dob format was wrong.

## Changes
- added default dashboard when clientUrl is not set
- fixed dob format to MM-DD-YYYY

## Testing
Tested locally.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects