### PR TITLE
fix: display dialog when there are multi env parameter

### DIFF
--- a/app/Layout.tsx
+++ b/app/Layout.tsx
@@ -10,14 +10,15 @@ import { CustomizableDialog } from '~/features/customConfig/components/Customiza
 export default function Layout({ children }: PropsWithChildren) {
   const brand = useBrand();
   const [searchParams] = useSearchParams();
+  const configState = searchParams.get('configState');
   const dummyBrand = searchParams.get('dummyBrand');
   const realBrand = searchParams.get('realBrand');
   const isConfigHidden = searchParams.get('configOpen') === 'false';
 
   const shouldShowDialog = useMemo(() => {
-    // if (!dummyBrand && !realBrand) return false;
+    if (!dummyBrand && !realBrand && !configState) return false;
     return !isConfigHidden;
-  }, [dummyBrand, isConfigHidden, realBrand]);
+  }, [configState, dummyBrand, isConfigHidden, realBrand]);
 
   return (
     <Box sx={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>


### PR DESCRIPTION
## Summary
Conditionally displays 1CS dialog customization when the config state and brands are present. Fallback to normal 1CS.

[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->

## Changes
<!---
List all non-trivial changes included in this PR. Bullet points are fine or the individual commits that make up this PR.
--->

## Testing
<!---
How did you test your changes? How might someone else test them?
--->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [ ] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects