### PR TITLE
fix: pass prisma singleton through context

### DIFF
--- a/app/coreAPI.server.ts
+++ b/app/coreAPI.server.ts
@@ -328,14 +328,6 @@ export const oneClick = async (
     }
   }
 
-  // if the redirectUrl is not provided, add the configState query parameter to the requestUrl
-  if (!partial?.redirectUrl) {
-    const url = new URL(options.requestUrl);
-    url.searchParams.set('configState', `${options.stateUuid}`);
-    url.searchParams.set('configOpen', 'false');
-    partial.redirectUrl = url.toString();
-  }
-
   const headers = {
     Authorization: 'Bearer ' + options.accessToken,
     'Content-Type': 'application/json',

--- a/app/coreAPI.server.ts
+++ b/app/coreAPI.server.ts
@@ -304,7 +304,12 @@ export const getSharedCredentialsOneClick = async (
  */
 export const oneClick = async (
   partial: Partial<OneClickOptions>,
-  options: { baseUrl: string; accessToken: string; stateUuid?: string }
+  options: {
+    baseUrl: string;
+    accessToken: string;
+    stateUuid?: string;
+    requestUrl: URL;
+  }
 ): Promise<{ url: string; phone: string }> => {
   const { phone } = partial;
 
@@ -313,8 +318,20 @@ export const oneClick = async (
     throw new Error('Phone was not provided');
   }
 
+  // if the redirectUrl is provided and is the same origin as the demo, add the configState query parameter
+  if (partial.redirectUrl) {
+    if (partial.redirectUrl.includes(options.requestUrl.hostname)) {
+      const url = new URL(partial.redirectUrl);
+      url.searchParams.set('configState', `${options.stateUuid}`);
+      partial.redirectUrl = url.toString();
+    }
+  }
+
+  // if the redirectUrl is not provided, add the configState query parameter to the requestUrl
   if (!partial?.redirectUrl) {
-    partial.redirectUrl = `${config.demoUrl}?configState=${options.stateUuid}`;
+    const url = new URL(options.requestUrl);
+    url.searchParams.set('configState', `${options.stateUuid}`);
+    partial.redirectUrl = url.toString();
   }
 
   const headers = {

--- a/app/coreAPI.server.ts
+++ b/app/coreAPI.server.ts
@@ -323,6 +323,7 @@ export const oneClick = async (
     if (partial.redirectUrl.includes(options.requestUrl.hostname)) {
       const url = new URL(partial.redirectUrl);
       url.searchParams.set('configState', `${options.stateUuid}`);
+      url.searchParams.set('configOpen', 'false');
       partial.redirectUrl = url.toString();
     }
   }
@@ -331,6 +332,7 @@ export const oneClick = async (
   if (!partial?.redirectUrl) {
     const url = new URL(options.requestUrl);
     url.searchParams.set('configState', `${options.stateUuid}`);
+    url.searchParams.set('configOpen', 'false');
     partial.redirectUrl = url.toString();
   }
 

--- a/app/features/customConfig/components/CustomizableDialog/components/EnvironmentStep.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/components/EnvironmentStep.tsx
@@ -90,7 +90,7 @@ export function EnvironmentStep({
           sx={{ fontSize: '15px' }}
           startIcon={<PlayArrow />}
           disabled={
-            !formContext.formState.isValid || formContext.formState.isSubmitting
+            !environment.field.value || formContext.formState.isSubmitting
           }
         >
           Start Demo

--- a/app/features/customConfig/components/CustomizableDialog/index.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/index.tsx
@@ -50,11 +50,20 @@ export function CustomizableDialog() {
 
   const form = useForm<CustomDemoForm>({
     resolver: zodResolver(customDemoFormSchema),
-    defaultValues: mapFormState(
-      routerData?.configState?.state || {
-        credentialRequests: defaultCredentialRequests,
+    defaultValues: async () => {
+      const url = new URL(window.location.href);
+      const defaultValues = mapFormState(
+        routerData?.configState?.state || {
+          credentialRequests: defaultCredentialRequests,
+        }
+      );
+
+      if (!defaultValues.redirectUrl) {
+        defaultValues.redirectUrl = url.toString();
       }
-    ),
+
+      return defaultValues;
+    },
     mode: 'all',
   });
   const { isDirty } = form.formState;

--- a/app/features/customConfig/components/CustomizableDialog/index.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useRouteLoaderData, useSearchParams } from '@remix-run/react';
 import { FormProvider, useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -48,22 +48,21 @@ export function CustomizableDialog() {
   const [dialogOpen, setDialogOpen] = useState(true);
   const [showDetailStep, setShowDetailStep] = useState(false);
 
+  const url =
+    typeof window !== 'undefined' ? new URL(window.location.href) : '';
+  const defaultValues = mapFormState(
+    routerData?.configState?.state || {
+      credentialRequests: defaultCredentialRequests,
+    }
+  );
+
+  if (!defaultValues.redirectUrl) {
+    defaultValues.redirectUrl = url.toString();
+  }
+
   const form = useForm<CustomDemoForm>({
     resolver: zodResolver(customDemoFormSchema),
-    defaultValues: async () => {
-      const url = new URL(window.location.href);
-      const defaultValues = mapFormState(
-        routerData?.configState?.state || {
-          credentialRequests: defaultCredentialRequests,
-        }
-      );
-
-      if (!defaultValues.redirectUrl) {
-        defaultValues.redirectUrl = url.toString();
-      }
-
-      return defaultValues;
-    },
+    defaultValues,
     mode: 'all',
   });
   const { isDirty } = form.formState;

--- a/app/features/customConfig/components/CustomizableDialog/index.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/index.tsx
@@ -57,6 +57,7 @@ export function CustomizableDialog() {
     ),
     mode: 'all',
   });
+  const { isDirty } = form.formState;
 
   const handleFormSubmission = async (data: CustomDemoForm) => {
     searchParams.set(
@@ -75,22 +76,22 @@ export function CustomizableDialog() {
     dummyBrand && formData.set('dummyBrand', dummyBrand);
     realBrand && formData.set('realBrand', realBrand);
 
-    const response = await fetch(path(), {
-      method: 'POST',
-      body: formData,
-    });
-    const { data: state } = await response.json();
+    if (isDirty) {
+      const response = await fetch(path(), {
+        method: 'POST',
+        body: formData,
+      });
+      const { data: state } = await response.json();
 
-    console.log('custom demo state saved', state);
+      console.log('custom demo state saved', state);
 
-    // Update url with the current state
-    searchParams.set('configState', state.uuid);
+      // Update url with the current state
+      searchParams.set('configState', state.uuid);
+    }
+
     setSearchParams(searchParams);
     setDialogOpen(false);
   };
-  useEffect(() => {
-    console.log('form.formState.isValid', form.formState.isValid);
-  }, [form.formState]);
 
   return (
     <Dialog open={dialogOpen} sx={dialogStyle}>

--- a/app/features/oneClick/useCases/getOneClickUseCase.ts
+++ b/app/features/oneClick/useCases/getOneClickUseCase.ts
@@ -1,11 +1,23 @@
+import type { AppLoadContext } from '@remix-run/node';
+import { PrismaClient } from '@prisma/client';
+
 import { logger } from '~/logger.server';
 import { getDBOneClick, getSharedCredentialsOneClick } from '~/coreAPI.server';
 import { getBrandSet } from '~/utils/getBrandSet';
 
-export async function getOneClickUseCase({ request }: { request: Request }) {
+export async function getOneClickUseCase({
+  context,
+  request,
+}: {
+  context: AppLoadContext;
+  request: Request;
+}) {
   const url = new URL(request.url);
   const { searchParams } = url;
-  const brandSet = await getBrandSet(searchParams);
+  const brandSet = await getBrandSet(
+    context.prisma as PrismaClient,
+    searchParams
+  );
 
   const oneClickUuid = searchParams.get('1ClickUuid');
 

--- a/app/features/state/services/findState.ts
+++ b/app/features/state/services/findState.ts
@@ -1,13 +1,15 @@
+import { PrismaClient } from '@prisma/client';
 import { findStateByUuid } from 'prisma/state';
 
 import { MappedState } from '~/features/state/types';
 import { mapState } from '~/features/state/mappers/mapState';
 
 export async function findState(
+  prisma: PrismaClient,
   uuid?: string | undefined | null
 ): Promise<MappedState | null> {
   if (!uuid) return null;
-  const state = await findStateByUuid(uuid);
+  const state = await findStateByUuid(prisma, uuid);
   if (!state) return null;
 
   state.state = mapState(state.state) as unknown as string;

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -20,6 +20,7 @@ import {
   ThemeProvider,
   unstable_useEnhancedEffect as useEnhancedEffect,
 } from '@mui/material';
+import { PrismaClient } from '@prisma/client';
 
 import { config } from './config';
 import { initLogRocket } from './logrocket';
@@ -76,7 +77,10 @@ export const links: LinksFunction = () => [
 export const loader: LoaderFunction = async ({ context, request }) => {
   const url = new URL(request.url);
   const searchParams = new URLSearchParams(url.searchParams);
-  const brandSet = await getBrandSet(searchParams);
+  const brandSet = await getBrandSet(
+    context.prisma as PrismaClient,
+    searchParams
+  );
 
   const { cspNonce } = context;
   const {

--- a/app/routes/account.tsx
+++ b/app/routes/account.tsx
@@ -6,11 +6,11 @@ import { Box, Typography, Stack, TextField, Button } from '@mui/material';
 import { getOneClickUseCase } from '~/features/oneClick/useCases/getOneClickUseCase';
 import { usePersonalInformationFields } from '~/features/personalInformation/hooks/usePersonalInformationFields';
 
-export const loader: LoaderFunction = async ({ request }) => {
+export const loader: LoaderFunction = async ({ context, request }) => {
   const url = new URL(request.url);
   const { searchParams } = url;
 
-  const oneClick = await getOneClickUseCase({ request });
+  const oneClick = await getOneClickUseCase({ context, request });
 
   if (oneClick?.success) return json(oneClick.success);
 

--- a/app/routes/favicon.tsx
+++ b/app/routes/favicon.tsx
@@ -1,6 +1,7 @@
 import { LoaderFunction, Response } from '@remix-run/node';
 import axios from 'axios';
 import sharp from 'sharp';
+import { PrismaClient } from '@prisma/client';
 
 import { logger } from '~/logger.server';
 import { Brand, getBrand } from '~/utils/getBrand';
@@ -15,10 +16,13 @@ const toWebp = async (buffer: ArrayBuffer): Promise<Buffer> => {
  * Loader function to fetch the favicon for the brand.
  * Return default favicon if brand is not found.
  */
-export const loader: LoaderFunction = async ({ request }) => {
+export const loader: LoaderFunction = async ({ request, context }) => {
   const url = new URL(request.url);
   const searchParams = new URLSearchParams(url.searchParams);
-  const brandSet = await getBrandSet(searchParams);
+  const brandSet = await getBrandSet(
+    context.prisma as PrismaClient,
+    searchParams
+  );
   const brand: Brand | null = brandSet.brand;
 
   try {

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -31,9 +31,9 @@ export const action: ActionFunction = async ({ request }) => {
 };
 
 // The exported `loader` function will be called when the route makes a GET request, i.e. when it is rendered
-export const loader: LoaderFunction = async ({ request }) => {
+export const loader: LoaderFunction = async ({ request, context }) => {
   // requireSession will redirect to the login page if the required params is not present to return the required data
-  const session = await requireSession(request);
+  const session = await requireSession(request, context);
   // return the session to the route, so it can be displayed
   return json({ session });
 };

--- a/app/routes/personal-information.tsx
+++ b/app/routes/personal-information.tsx
@@ -16,11 +16,11 @@ import { PersonalInformationLoader } from '~/features/personalInformation/types'
 import { getOneClickUseCase } from '~/features/oneClick/useCases/getOneClickUseCase';
 import { InputMask } from '~/components/InputMask';
 
-export const loader: LoaderFunction = async ({ request }) => {
+export const loader: LoaderFunction = async ({ request, context }) => {
   const url = new URL(request.url);
   const { searchParams } = url;
 
-  const oneClick = await getOneClickUseCase({ request });
+  const oneClick = await getOneClickUseCase({ context, request });
 
   if (oneClick?.success) return json(oneClick.success);
 

--- a/app/routes/register.tsx
+++ b/app/routes/register.tsx
@@ -115,6 +115,7 @@ export const action: ActionFunction = async ({ request, context }) => {
           baseUrl: getBaseUrl(configState?.state.environment),
           accessToken: brandSet.apiKey,
           stateUuid: configState?.uuid,
+          requestUrl: url,
         });
 
         logger.info(`oneClick result: ${JSON.stringify(result)}`);

--- a/app/routes/register.tsx
+++ b/app/routes/register.tsx
@@ -6,6 +6,7 @@ import {
 } from '@remix-run/node';
 import Box from '@mui/material/Box';
 import { Server } from 'socket.io';
+import { PrismaClient } from '@prisma/client';
 
 import { getErrorMessage, getErrorStatus } from '~/errors';
 import {
@@ -34,7 +35,7 @@ import { findState } from '~/features/state/services/findState';
 import { getBaseUrl } from '~/features/environment/helpers';
 
 // The exported `action` function will be called when the route makes a POST request, i.e. when the form is submitted.
-export const action: ActionFunction = async ({ request }) => {
+export const action: ActionFunction = async ({ request, context }) => {
   const url = new URL(request.url);
   const searchParams = new URLSearchParams(url.searchParams);
   const formData = await request.formData();
@@ -49,10 +50,16 @@ export const action: ActionFunction = async ({ request }) => {
     searchParams.get('verificationOptions') || 'only_code';
   const isHosted = searchParams.get('isHosted') !== 'false' ?? true;
 
-  const brandSet = await getBrandSet(searchParams);
+  const brandSet = await getBrandSet(
+    context.prisma as PrismaClient,
+    searchParams
+  );
 
   const configStateParams = searchParams.get('configState');
-  const configState = await findState(configStateParams);
+  const configState = await findState(
+    context.prisma as PrismaClient,
+    configStateParams
+  );
 
   if (!action) {
     return json({ error: 'Action must be populated' }, { status: 400 });
@@ -176,7 +183,10 @@ export const action: ActionFunction = async ({ request }) => {
 export const loader: LoaderFunction = async ({ request, context }) => {
   const url = new URL(request.url);
   const { searchParams } = url;
-  const brandSet = await getBrandSet(searchParams);
+  const brandSet = await getBrandSet(
+    context.prisma as PrismaClient,
+    searchParams
+  );
 
   const oneClickUuid = searchParams.get('1ClickUuid');
   const configStateParam = searchParams.get('configState');
@@ -184,7 +194,10 @@ export const loader: LoaderFunction = async ({ request, context }) => {
   let configState = null;
 
   if (configStateParam) {
-    const state = await findState(configStateParam);
+    const state = await findState(
+      context.prisma as PrismaClient,
+      configStateParam
+    );
     configState = state;
   }
 

--- a/app/routes/verified.tsx
+++ b/app/routes/verified.tsx
@@ -38,9 +38,9 @@ export const action: ActionFunction = async ({ request }) => {
 };
 
 // The exported `loader` function will be called when the route makes a GET request, i.e. when it is rendered
-export const loader: LoaderFunction = async ({ request }) => {
+export const loader: LoaderFunction = async ({ request, context }) => {
   // requireSession will redirect to the login page if the required params is not present to return the required data
-  const session = await requireSession(request);
+  const session = await requireSession(request, context);
   // return the session to the route, so it can be displayed
   return json({ session });
 };

--- a/app/session.server.ts
+++ b/app/session.server.ts
@@ -1,4 +1,9 @@
-import { createCookieSessionStorage, redirect } from '@remix-run/node';
+import {
+  AppLoadContext,
+  createCookieSessionStorage,
+  redirect,
+} from '@remix-run/node';
+import { PrismaClient } from '@prisma/client';
 
 import { config } from './config';
 import { Brand } from './utils/getBrand';
@@ -70,14 +75,20 @@ export const logout = async (request: Request, redirectUrl?: string) => {
  * @param {Request} request
  * @returns {Promise<OneClickDto>} oneClickDto
  */
-export const requireSession = async (request: Request) => {
+export const requireSession = async (
+  request: Request,
+  context: AppLoadContext
+) => {
   const url = new URL(request.url);
   const searchParams = new URLSearchParams(url.searchParams);
 
   const oneClickUuid = searchParams.get('1ClickUuid');
 
   if (oneClickUuid) {
-    const brandSet = await getBrandSet(searchParams);
+    const brandSet = await getBrandSet(
+      context.prisma as PrismaClient,
+      searchParams
+    );
     const result = await getSharedCredentialsOneClick(
       brandSet.apiKey,
       oneClickUuid

--- a/app/utils/getBrandSet.ts
+++ b/app/utils/getBrandSet.ts
@@ -1,4 +1,5 @@
 import { BrandDto } from '@verifiedinc/core-types';
+import { PrismaClient } from '@prisma/client';
 
 import { config } from '~/config';
 import { getBrandApiKey, getBrandDto } from '~/coreAPI.server';
@@ -9,13 +10,16 @@ import { logger } from '~/logger.server';
 import { findState } from '~/features/state/services/findState';
 import { getAdminKey, getBaseUrl, ifEnv } from '~/features/environment/helpers';
 
-export const getBrandSet = async (searchParams: URLSearchParams) => {
+export const getBrandSet = async (
+  prisma: PrismaClient,
+  searchParams: URLSearchParams
+) => {
   let brand = getBrand(null);
   let apiKey = config.verifiedApiKey;
 
   // Allow custom branding under environment flag.
   if (config.customBrandingEnabled) {
-    const state = await findState(searchParams.get('configState'));
+    const state = await findState(prisma, searchParams.get('configState'));
     const brandParam = searchParams.get('brand');
     const dummyBrandParam = searchParams.get('dummyBrand') || state?.dummyBrand;
     const realBrandParam = searchParams.get('realBrand') || state?.realBrand;

--- a/prisma/prisma.js
+++ b/prisma/prisma.js
@@ -1,0 +1,6 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { PrismaClient } = require('@prisma/client');
+
+const prisma = new PrismaClient();
+
+module.exports = prisma;

--- a/prisma/state.ts
+++ b/prisma/state.ts
@@ -1,25 +1,17 @@
 import { PrismaClient } from '@prisma/client';
 
-const prisma = new PrismaClient();
-
-export const findStateByUuid = async (uuid: string): Promise<State | null> => {
-  try {
-    prisma.$connect();
-    return prisma.state.findFirst({ where: { uuid } });
-  } finally {
-    prisma.$disconnect();
-  }
+export const findStateByUuid = async (
+  prisma: PrismaClient,
+  uuid: string
+): Promise<State | null> => {
+  return prisma.state.findFirst({ where: { uuid } });
 };
 
 export const createState = async (
+  prisma: PrismaClient,
   options: Pick<State, 'state' | 'dummyBrand' | 'realBrand'>
 ): Promise<State> => {
-  try {
-    prisma.$connect();
-    return await prisma.state.create({ data: options });
-  } finally {
-    prisma.$disconnect();
-  }
+  return prisma.state.create({ data: options });
 };
 
 export type State = {

--- a/server.js
+++ b/server.js
@@ -8,6 +8,9 @@ const helmet = require('helmet');
 const { createRequestHandler } = require('@remix-run/express');
 const http = require('http');
 const socketIo = require('./app/lib/socket-io');
+const prisma = require('./prisma/prisma');
+
+console.log(prisma);
 
 const BUILD_DIR = path.join(process.cwd(), 'build');
 
@@ -120,6 +123,7 @@ app.all(
           getLoadContext: () => ({
             cspNonce: res.locals.cspNonce,
             socketIo: socketIo.getInstance(),
+            prisma,
           }),
         })(req, res, next);
       }
@@ -131,6 +135,7 @@ app.all(
           getLoadContext: () => ({
             cspNonce: res.locals.cspNonce,
             socketIo: socketIo.getInstance(),
+            prisma,
           }),
         })(req, res, next);
       }


### PR DESCRIPTION
## Summary
Inject prisma through remix request context. Added default `redirectUrl` with a value for the demo page plus the `configState` query parameter.

[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->

## Changes
- updated dialog form state

## Testing
Tested locally.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects