### PR TITLE
fix: get 1click result using brands from config state and favicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ docker pull postgres:latest
 Run image:
 
 ```sh
-docker run --name one-click-demo-db -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=password -e POSTGRES_DB=one_click_demo -p 5444:5432 -d postgres
+docker run --name one-click-demo-db -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=password -e POSTGRES_DB=oneclick_demo -p 5444:5432 -d postgres
 ```
 
 #### Migration And Entity

--- a/app/coreAPI.server.ts
+++ b/app/coreAPI.server.ts
@@ -432,11 +432,11 @@ export const getBrandDto = async (
  */
 export const getBrandApiKey = async (
   brandUuid: string,
-  options: { accessToken: string; baseUrl: string }
+  options: { apiKey: string; baseUrl: string }
 ): Promise<string> => {
   try {
     const headers = {
-      Authorization: 'Bearer ' + options.accessToken,
+      Authorization: 'Bearer ' + options.apiKey,
       'Content-Type': 'application/json',
     };
 

--- a/app/coreAPI.server.ts
+++ b/app/coreAPI.server.ts
@@ -253,16 +253,16 @@ export const sharedCredentials = async (uuid: string) => {
  * @returns {Promise<OneClickDto | null>} if a match for the request is found, returns the shared credentials, if no match is found returns null
  */
 export const getSharedCredentialsOneClick = async (
-  apiKey: string,
-  uuid: string
+  uuid: string,
+  options: { baseUrl: string; accessToken: string }
 ) => {
   const headers = {
-    Authorization: 'Bearer ' + apiKey,
+    Authorization: 'Bearer ' + options.accessToken,
     'Content-Type': 'application/json',
   };
 
   try {
-    const response = await fetch(config.coreServiceUrl + '/1-click/' + uuid, {
+    const response = await fetch(options.baseUrl + '/1-click/' + uuid, {
       method: 'GET',
       headers,
     });

--- a/app/coreAPI.server.ts
+++ b/app/coreAPI.server.ts
@@ -400,11 +400,11 @@ const mapBrandDto = (brandDto: BrandDto): Partial<BrandDto> => ({
  */
 export const getBrandDto = async (
   brandUuid: string,
-  options: { baseUrl: string; apiKey: string }
+  options: { baseUrl: string; adminKey: string }
 ): Promise<Partial<BrandDto> | null> => {
   try {
     const headers = {
-      Authorization: 'Bearer ' + options.apiKey,
+      Authorization: 'Bearer ' + options.adminKey,
       'Content-Type': 'application/json',
     };
 
@@ -432,11 +432,11 @@ export const getBrandDto = async (
  */
 export const getBrandApiKey = async (
   brandUuid: string,
-  options: { apiKey: string; baseUrl: string }
+  options: { adminKey: string; baseUrl: string }
 ): Promise<string> => {
   try {
     const headers = {
-      Authorization: 'Bearer ' + options.apiKey,
+      Authorization: 'Bearer ' + options.adminKey,
       'Content-Type': 'application/json',
     };
 

--- a/app/coreAPI.server.ts
+++ b/app/coreAPI.server.ts
@@ -254,10 +254,10 @@ export const sharedCredentials = async (uuid: string) => {
  */
 export const getSharedCredentialsOneClick = async (
   uuid: string,
-  options: { baseUrl: string; accessToken: string }
+  options: { baseUrl: string; apiKey: string }
 ) => {
   const headers = {
-    Authorization: 'Bearer ' + options.accessToken,
+    Authorization: 'Bearer ' + options.apiKey,
     'Content-Type': 'application/json',
   };
 
@@ -400,11 +400,11 @@ const mapBrandDto = (brandDto: BrandDto): Partial<BrandDto> => ({
  */
 export const getBrandDto = async (
   brandUuid: string,
-  options: { baseUrl: string; accessToken: string }
+  options: { baseUrl: string; apiKey: string }
 ): Promise<Partial<BrandDto> | null> => {
   try {
     const headers = {
-      Authorization: 'Bearer ' + options.accessToken,
+      Authorization: 'Bearer ' + options.apiKey,
       'Content-Type': 'application/json',
     };
 

--- a/app/features/oneClick/useCases/getOneClickUseCase.ts
+++ b/app/features/oneClick/useCases/getOneClickUseCase.ts
@@ -41,7 +41,7 @@ export async function getOneClickUseCase({
     logger.info('1click uuid value found and opted out is not true');
     const oneClick = await getSharedCredentialsOneClick(oneClickUuid, {
       baseUrl: getBaseUrl(configState.state.environment),
-      accessToken: brandSet.apiKey,
+      apiKey: brandSet.apiKey,
     });
     const oneClickDB = await getDBOneClick(oneClickUuid);
 

--- a/app/features/oneClick/useCases/getOneClickUseCase.ts
+++ b/app/features/oneClick/useCases/getOneClickUseCase.ts
@@ -4,6 +4,9 @@ import { PrismaClient } from '@prisma/client';
 import { logger } from '~/logger.server';
 import { getDBOneClick, getSharedCredentialsOneClick } from '~/coreAPI.server';
 import { getBrandSet } from '~/utils/getBrandSet';
+import { MappedState } from '~/features/state/types';
+import { findState } from '~/features/state/services/findState';
+import { getBaseUrl } from '~/features/environment/helpers';
 
 export async function getOneClickUseCase({
   context,
@@ -21,16 +24,25 @@ export async function getOneClickUseCase({
 
   const oneClickUuid = searchParams.get('1ClickUuid');
   const optedOut = url.searchParams.get('optedOut');
+  const configStateParam = searchParams.get('configState');
+  let configState: MappedState | null = null;
+
+  if (configStateParam) {
+    configState = await findState(
+      context.prisma as PrismaClient,
+      configStateParam
+    );
+  }
 
   logger.info(`optedOut value ${optedOut}`);
 
   // if the oneClickUuid is present and the user has not opted out
-  if (oneClickUuid && optedOut !== 'true') {
+  if (oneClickUuid && optedOut !== 'true' && configState) {
     logger.info('1click uuid value found and opted out is not true');
-    const oneClick = await getSharedCredentialsOneClick(
-      brandSet.apiKey,
-      oneClickUuid
-    );
+    const oneClick = await getSharedCredentialsOneClick(oneClickUuid, {
+      baseUrl: getBaseUrl(configState.state.environment),
+      accessToken: brandSet.apiKey,
+    });
     const oneClickDB = await getDBOneClick(oneClickUuid);
 
     if (oneClick && oneClickDB) {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -111,6 +111,7 @@ export const loader: LoaderFunction = async ({ context, request }) => {
       bookACallUrl,
     },
     ...brandSet,
+    queryString: searchParams.toString(),
   });
 };
 
@@ -119,14 +120,18 @@ interface DocumentProps {
   cspNonce: string;
   env: BrowserConfig;
   brand: Brand;
+  queryString: string;
 }
 
 // set up Emotion for mui styles
 // ref: https://github.com/mui/material-ui/blob/master/examples/remix-with-typescript/app/root.tsx
 const Document = withEmotionCache(
-  ({ children, cspNonce, env, brand }: DocumentProps, emotionCache) => {
+  (
+    { children, cspNonce, env, brand, queryString }: DocumentProps,
+    emotionCache
+  ) => {
     const clientStyleData = useContext(ClientStyleContext);
-    const favicon = `/favicon?brand=${brand.uuid}`;
+    const favicon = `/favicon?${queryString}`;
 
     // only executed on client
     useEnhancedEffect(() => {
@@ -213,7 +218,7 @@ export function ErrorBoundary({ error }: { error: unknown }) {
 }
 
 export default function App() {
-  let { cspNonce, env, brand } = useLoaderData<typeof loader>();
+  let { cspNonce, env, brand, queryString } = useLoaderData<typeof loader>();
 
   // fixes an issue with the nonce being reapplied on client hydration, and every time the loader is called
   // ref: https://github.com/remix-run/remix/issues/183
@@ -227,7 +232,12 @@ export default function App() {
   }, []);
 
   return (
-    <Document cspNonce={cspNonce} env={env} brand={brand}>
+    <Document
+      cspNonce={cspNonce}
+      env={env}
+      brand={brand}
+      queryString={queryString}
+    >
       <Outlet />
     </Document>
   );

--- a/app/routes/register.tsx
+++ b/app/routes/register.tsx
@@ -206,7 +206,7 @@ export const loader: LoaderFunction = async ({ request, context }) => {
   if (oneClickUuid && !hasOptedOut) {
     const result = await getSharedCredentialsOneClick(oneClickUuid, {
       baseUrl: getBaseUrl(configState?.state.environment),
-      accessToken: brandSet.apiKey,
+      apiKey: brandSet.apiKey,
     });
     if (result) {
       // Emit the 1-click successful event to the socket.io room.

--- a/app/routes/register.tsx
+++ b/app/routes/register.tsx
@@ -204,10 +204,10 @@ export const loader: LoaderFunction = async ({ request, context }) => {
   }
 
   if (oneClickUuid && !hasOptedOut) {
-    const result = await getSharedCredentialsOneClick(
-      brandSet.apiKey,
-      oneClickUuid
-    );
+    const result = await getSharedCredentialsOneClick(oneClickUuid, {
+      baseUrl: getBaseUrl(configState?.state.environment),
+      accessToken: brandSet.apiKey,
+    });
     if (result) {
       // Emit the 1-click successful event to the socket.io room.
       logger.debug(

--- a/app/session.server.ts
+++ b/app/session.server.ts
@@ -104,7 +104,7 @@ export const requireSession = async (
 
     const result = await getSharedCredentialsOneClick(oneClickUuid, {
       baseUrl: getBaseUrl(configState.state.environment),
-      accessToken: brandSet.apiKey,
+      apiKey: brandSet.apiKey,
     });
 
     if (result) return result;

--- a/app/utils/getBrandSet.ts
+++ b/app/utils/getBrandSet.ts
@@ -40,16 +40,19 @@ export const getBrandSet = async (
     if (brandUuid) {
       logger.info(`getting brand: ${brandUuid}`);
 
+      const baseUrl = getBaseUrl(environment);
+      const accessToken = getAdminKey(environment);
+
       apiKey = await getBrandApiKey(brandUuid, {
-        baseUrl: getBaseUrl(environment),
-        accessToken: getAdminKey(environment),
+        baseUrl,
+        accessToken,
       });
 
       logger.info(`got api key: ${apiKey}`);
 
       const brandDto = await getBrandDto(brandUuid, {
-        baseUrl: getBaseUrl(environment),
-        accessToken: getAdminKey(environment),
+        baseUrl,
+        accessToken,
       });
 
       brand = getBrand(brandUuid ? (brandDto as BrandDto) : null);

--- a/app/utils/getBrandSet.ts
+++ b/app/utils/getBrandSet.ts
@@ -45,14 +45,14 @@ export const getBrandSet = async (
 
       apiKey = await getBrandApiKey(brandUuid, {
         baseUrl,
-        apiKey: adminKey,
+        adminKey,
       });
 
       logger.info(`got api key: ${apiKey}`);
 
       const brandDto = await getBrandDto(brandUuid, {
         baseUrl,
-        apiKey: adminKey,
+        adminKey,
       });
 
       brand = getBrand(brandUuid ? (brandDto as BrandDto) : null);

--- a/app/utils/getBrandSet.ts
+++ b/app/utils/getBrandSet.ts
@@ -52,7 +52,7 @@ export const getBrandSet = async (
 
       const brandDto = await getBrandDto(brandUuid, {
         baseUrl,
-        accessToken,
+        apiKey: accessToken,
       });
 
       brand = getBrand(brandUuid ? (brandDto as BrandDto) : null);

--- a/app/utils/getBrandSet.ts
+++ b/app/utils/getBrandSet.ts
@@ -41,18 +41,18 @@ export const getBrandSet = async (
       logger.info(`getting brand: ${brandUuid}`);
 
       const baseUrl = getBaseUrl(environment);
-      const accessToken = getAdminKey(environment);
+      const adminKey = getAdminKey(environment);
 
       apiKey = await getBrandApiKey(brandUuid, {
         baseUrl,
-        accessToken,
+        apiKey: adminKey,
       });
 
       logger.info(`got api key: ${apiKey}`);
 
       const brandDto = await getBrandDto(brandUuid, {
         baseUrl,
-        apiKey: accessToken,
+        apiKey: adminKey,
       });
 
       brand = getBrand(brandUuid ? (brandDto as BrandDto) : null);


### PR DESCRIPTION
## Summary
Fixed get one click using multi env and favicon display.

[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->

## Changes
<!---
List all non-trivial changes included in this PR. Bullet points are fine or the individual commits that make up this PR.
--->

## Testing
<!---
How did you test your changes? How might someone else test them?
--->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [ ] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects