### PR TITLE
fix default values non hosted

### DIFF
--- a/app/features/customConfig/components/CustomizableDialog/components/DataFieldOptionType.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/components/DataFieldOptionType.tsx
@@ -23,6 +23,7 @@ export function DataFieldOptionType() {
         label: schema.$id,
         id: schema.$id,
       }))
+      .filter((schema) => schema.id !== 'IdentityCredential')
       .sort((a, b) => (a.label < b.label ? -1 : 1));
   }, [schemas]);
   const selectedValue = useMemo(() => {

--- a/app/features/customConfig/components/CustomizableDialog/components/DataFieldOptionType.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/components/DataFieldOptionType.tsx
@@ -23,7 +23,10 @@ export function DataFieldOptionType() {
         label: schema.$id,
         id: schema.$id,
       }))
-      .filter((schema) => schema.id !== 'IdentityCredential')
+      .filter((schema) => {
+        const blacklist = ['IdentityCredential'];
+        return !blacklist.includes(schema.id);
+      })
       .sort((a, b) => (a.label < b.label ? -1 : 1));
   }, [schemas]);
   const selectedValue = useMemo(() => {

--- a/app/features/customConfig/components/CustomizableDialog/components/DescriptionField.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/components/DescriptionField.tsx
@@ -10,20 +10,9 @@ export function DescriptionField() {
   const field = useController<CustomDemoForm>({
     name: 'content.description',
   });
-
-  const [value, setValue] = useState(field.field.value || '');
-
-  const debounceChange = useRef(
-    debounce((value: string) => {
-      // Update form state
-      field.field.onChange({ target: { value } });
-    }, 500)
-  ).current;
-
-  const handleChange = (e: any) => {
-    setValue(e.target.value);
-    debounceChange(e.target.value);
-  };
+  const isHosted = useController<CustomDemoForm>({
+    name: 'isHosted',
+  });
 
   return (
     <SectionAccordion
@@ -38,8 +27,10 @@ export function DescriptionField() {
     >
       <TextField
         {...field.field}
-        value={value}
-        onChange={handleChange}
+        value={field.field.value}
+        onChange={(e) => {
+          field.field.onChange({ target: { value: e.target.value } });
+        }}
         error={!!field.fieldState.error}
         helperText={
           field.fieldState.error?.message || 'Optional — defaults to empty'
@@ -48,6 +39,7 @@ export function DescriptionField() {
         color='success'
         size='small'
         className='original'
+        disabled={!isHosted.field.value}
       />
     </SectionAccordion>
   );

--- a/app/features/customConfig/components/CustomizableDialog/components/HostedField.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/components/HostedField.tsx
@@ -1,4 +1,4 @@
-import { useController } from 'react-hook-form';
+import { useController, useFormContext } from 'react-hook-form';
 import { RadioGroup } from '@mui/material';
 
 import { useBrand } from '~/hooks/useBrand';
@@ -6,12 +6,14 @@ import { useBrand } from '~/hooks/useBrand';
 import { CustomDemoForm } from '~/features/customConfig/validators/form';
 import { SectionAccordion } from '~/features/customConfig/components/CustomizableDialog/components/SectionAccordion';
 import { RadioOption } from '~/features/customConfig/components/CustomizableDialog/components/RadioOption';
+import { OneClickContentTitle } from '~/features/customConfig/types';
 
 export function HostedField() {
   const brand = useBrand();
   const isHosted = useController<CustomDemoForm>({
     name: 'isHosted',
   });
+  const form = useFormContext<CustomDemoForm>();
 
   return (
     <SectionAccordion
@@ -27,7 +29,17 @@ export function HostedField() {
       <RadioGroup
         value={isHosted.field.value}
         onChange={(_, value) => {
-          isHosted.field.onChange({ target: { value: value === 'true' } });
+          const isHostedValue = value === 'true';
+          isHosted.field.onChange({ target: { value: isHostedValue } });
+
+          if (!isHostedValue) {
+            const url = new URL(window.location.href);
+            form.setValue('content.title', OneClickContentTitle.Signup);
+            form.setValue('content.description', '');
+            form.setValue('redirectUrl', `${url.origin}/register`, {
+              shouldValidate: true,
+            });
+          }
         }}
       >
         <RadioOption

--- a/app/features/customConfig/components/CustomizableDialog/components/RedirectUrlField.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/components/RedirectUrlField.tsx
@@ -1,6 +1,4 @@
-import { useRef, useState } from 'react';
 import { useController } from 'react-hook-form';
-import { debounce } from 'lodash';
 import { TextField } from '@mui/material';
 
 import { CustomDemoForm } from '~/features/customConfig/validators/form';
@@ -8,20 +6,9 @@ import { SectionAccordion } from '~/features/customConfig/components/Customizabl
 
 export function RedirectUrlField() {
   const field = useController<CustomDemoForm>({ name: 'redirectUrl' });
-
-  const [value, setValue] = useState(field.field.value || '');
-
-  const debounceChange = useRef(
-    debounce((value: string) => {
-      // Update form state
-      field.field.onChange({ target: { value } });
-    }, 500)
-  ).current;
-
-  const handleChange = (e: any) => {
-    setValue(e.target.value);
-    debounceChange(e.target.value);
-  };
+  const isHosted = useController<CustomDemoForm>({
+    name: 'isHosted',
+  });
 
   return (
     <SectionAccordion
@@ -36,8 +23,10 @@ export function RedirectUrlField() {
     >
       <TextField
         {...field.field}
-        value={value}
-        onChange={handleChange}
+        value={field.field.value}
+        onChange={(e) => {
+          field.field.onChange({ target: { value: e.target.value } });
+        }}
         error={!!field.fieldState.error}
         helperText={
           field.fieldState.error?.message ||
@@ -47,6 +36,7 @@ export function RedirectUrlField() {
         color='success'
         size='small'
         className='original'
+        disabled={!isHosted.field.value}
       />
     </SectionAccordion>
   );

--- a/app/features/customConfig/components/CustomizableDialog/components/TitleField.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/components/TitleField.tsx
@@ -10,6 +10,9 @@ export function TitleField() {
   const title = useController<CustomDemoForm>({
     name: 'content.title',
   });
+  const isHosted = useController<CustomDemoForm>({
+    name: 'isHosted',
+  });
 
   return (
     <SectionAccordion
@@ -29,24 +32,28 @@ export function TitleField() {
           title={OneClickContentTitle.Signup}
           description='"1-Click Signup"'
           tip='Signup'
+          disabled={!isHosted.field.value}
         />
         <RadioOption
           value={OneClickContentTitle.Signin}
           title={OneClickContentTitle.Signin}
           description='"1-Click Signin"'
           tip='Signin'
+          disabled={!isHosted.field.value}
         />
         <RadioOption
           value={OneClickContentTitle.Verify}
           title={OneClickContentTitle.Verify}
           description='"1-Click Verify"'
           tip='Verify'
+          disabled={!isHosted.field.value}
         />
         <RadioOption
           value={OneClickContentTitle.Apply}
           title={OneClickContentTitle.Apply}
           description='"1-Click Apply"'
           tip='Apply'
+          disabled={!isHosted.field.value}
         />
       </RadioGroup>
     </SectionAccordion>

--- a/app/features/customConfig/components/CustomizableDialog/index.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/index.tsx
@@ -68,6 +68,20 @@ export function CustomizableDialog() {
   const { isDirty } = form.formState;
 
   const handleFormSubmission = async (data: CustomDemoForm) => {
+    const currentUrl = new URL(window.location.href);
+
+    // Redirect to personal-information if is non-hosted flow and no redirectUrl is provided
+    if (data.redirectUrl) {
+      const redirectUrl = new URL(data.redirectUrl);
+      if (currentUrl.pathname === redirectUrl.pathname && !data.isHosted) {
+        data.redirectUrl = `${redirectUrl.origin}/personal-information`;
+      }
+    } else {
+      if (!data.isHosted) {
+        data.redirectUrl = `${currentUrl.origin}/personal-information`;
+      }
+    }
+
     searchParams.set(
       'verificationOptions',
       data.verificationOptions.toString()

--- a/app/features/customConfig/components/CustomizableDialog/index.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/index.tsx
@@ -82,6 +82,21 @@ export function CustomizableDialog() {
       }
     }
 
+    // If the default types are changed, redirect to the verified page
+    const untouchedDefaultTypes = [
+      'FullNameCredential',
+      'EmailCredential',
+      'PhoneCredential',
+      'AddressCredential',
+      'BirthDateCredential',
+      'SsnCredential',
+    ].every((type) => {
+      return data.credentialRequests.some((request) => request.type === type);
+    });
+    if (!untouchedDefaultTypes) {
+      data.redirectUrl = `${currentUrl.origin}/verified`;
+    }
+
     searchParams.set(
       'verificationOptions',
       data.verificationOptions.toString()

--- a/app/features/customConfig/components/CustomizableDialog/index.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/index.tsx
@@ -93,7 +93,7 @@ export function CustomizableDialog() {
     ].every((type) => {
       return data.credentialRequests.some((request) => request.type === type);
     });
-    if (!untouchedDefaultTypes) {
+    if (!untouchedDefaultTypes && !data.isHosted) {
       data.redirectUrl = `${currentUrl.origin}/verified`;
     }
 

--- a/app/features/personalInformation/hooks/usePersonalInformationFields.ts
+++ b/app/features/personalInformation/hooks/usePersonalInformationFields.ts
@@ -12,6 +12,7 @@ import { PersonalInformationLoader } from '~/features/personalInformation/types'
 
 import { useField } from '~/hooks/useField';
 import { useMaskField } from '~/hooks/useMaskField';
+import { phoneSchema } from '~/validations/phone.schema';
 
 export function usePersonalInformationFields() {
   const {
@@ -49,6 +50,13 @@ export function usePersonalInformationFields() {
     label: 'Email',
     schema: emailSchema,
     initialValue: data.email,
+  });
+
+  const phone = useField({
+    name: 'phone',
+    label: 'Phone',
+    schema: phoneSchema,
+    initialValue: data.phone,
   });
 
   const line1 = useField({
@@ -138,11 +146,12 @@ export function usePersonalInformationFields() {
       middleName,
       lastName,
       email,
+      phone,
       line1,
       line2,
       city,
-      state,
       country,
+      state,
       zipCode,
       birthDate,
       ssn,
@@ -152,11 +161,12 @@ export function usePersonalInformationFields() {
       middleName,
       lastName,
       email,
+      phone,
       line1,
       line2,
       city,
-      state,
       country,
+      state,
       zipCode,
       birthDate,
       ssn,
@@ -168,6 +178,8 @@ export function usePersonalInformationFields() {
     () => [
       'firstName',
       'lastName',
+      'email',
+      'phone',
       'line1',
       'city',
       'state',

--- a/app/features/personalInformation/types.ts
+++ b/app/features/personalInformation/types.ts
@@ -4,6 +4,7 @@ export type PersonalInformationLoader = {
   oneClick: {
     credentials: {
       email?: string;
+      phone?: string;
       fullName?:
         | {
             firstName?: string;


### PR DESCRIPTION
## Summary
Fix non-hosted flow to redirect to personal-information, also update the form to reflect the default values. Another feature improvement is when non-hosted option is selected it will disable the title, description and redirect url.

[Ticket](https://trello.com/c/CADHMCKe/6857-fix-1click-demo-non-hosted-trusted-bug-of-form-page-not-being-shown-after-user-shares)
<!---
Link to the Trello ticket for this work.
--->

## Changes
- updated custom dialog
- updated personal info page

## Testing
Tested locally both hosted and non-hosted

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects