### PR TITLE
fix: form validity, add mock term, add disabled accordion state

### DIFF
--- a/app/features/customConfig/components/CustomizableDialog/components/CredentialRequestsField.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/components/CredentialRequestsField.tsx
@@ -55,6 +55,7 @@ function CredentialRequestField({
       })}
       {path === 'credentialRequests' && (
         <OriginalButton
+          type='button'
           onClick={() => {
             fieldArray.append({
               ...buildDataFieldValue('', customConfig.schemas!),

--- a/app/features/customConfig/components/CustomizableDialog/components/DescriptionField.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/components/DescriptionField.tsx
@@ -24,6 +24,9 @@ export function DescriptionField() {
           <pre>{`{\n  content?: {\n    description?: string \n  }\n}`}</pre>
         </>
       }
+      sx={{
+        opacity: isHosted.field.value ? 1 : 0.5,
+      }}
     >
       <TextField
         {...field.field}

--- a/app/features/customConfig/components/CustomizableDialog/components/EnvironmentStep.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/components/EnvironmentStep.tsx
@@ -67,7 +67,7 @@ export function EnvironmentStep({
                   textAlign: 'left !important',
                 }}
               >
-                Dummy or Real Data
+                Mock or Real Data
               </Typography>
               <Tip>
                 <>
@@ -80,8 +80,8 @@ export function EnvironmentStep({
           </Stack>
           <RadioGroup {...environment.field}>
             <RadioOption
-              value='dummy'
-              title='Dummy data (sandbox)'
+              value='mock'
+              title='Mock data (sandbox)'
               description='Random example data'
               tip='Sandbox'
             />
@@ -100,7 +100,9 @@ export function EnvironmentStep({
           sx={{ fontSize: '15px' }}
           startIcon={<PlayArrow />}
           disabled={
-            !environment.field.value || formContext.formState.isSubmitting
+            !environment.field.value ||
+            !formContext.formState.isValid ||
+            formContext.formState.isSubmitting
           }
         >
           Start Demo

--- a/app/features/customConfig/components/CustomizableDialog/components/RedirectUrlField.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/components/RedirectUrlField.tsx
@@ -20,6 +20,9 @@ export function RedirectUrlField() {
           <pre>{`{\n  redirectUrl?: string\n}`}</pre>
         </>
       }
+      sx={{
+        opacity: isHosted.field.value ? 1 : 0.5,
+      }}
     >
       <TextField
         {...field.field}

--- a/app/features/customConfig/components/CustomizableDialog/components/TitleField.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/components/TitleField.tsx
@@ -25,6 +25,7 @@ export function TitleField() {
         </>
       }
       sx={{
+        opacity: isHosted.field.value ? 1 : 0.5,
         '& .MuiAccordionDetails-root': {
           py: 0.5,
         },

--- a/app/features/customConfig/components/CustomizableDialog/index.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/index.tsx
@@ -69,8 +69,14 @@ export function CustomizableDialog() {
   });
   const { isDirty } = form.formState;
 
-  const handleFormSubmission = async (data: CustomDemoForm) => {
+  const handleFormSubmission = async (_data: CustomDemoForm) => {
     const currentUrl = new URL(window.location.href);
+    const data = _data;
+
+    // Remove empty credential requests
+    data.credentialRequests = data.credentialRequests.filter(
+      (credentialRequest) => !!credentialRequest.type
+    );
 
     // Redirect to personal-information if is non-hosted flow and no redirectUrl is provided
     if (data.redirectUrl) {

--- a/app/features/customConfig/validators/form.ts
+++ b/app/features/customConfig/validators/form.ts
@@ -21,7 +21,7 @@ export const customDemoFormSchema = zod.object({
         allowUserInput: zod.boolean(),
         description: zod.string().optional(),
         mandatory: zod.nativeEnum(MandatoryEnum),
-        type: zod.string().min(1),
+        type: zod.string(),
         children: zod.array(zod.object({}).passthrough()).optional(),
       })
     )

--- a/app/styles/verified-theme.ts
+++ b/app/styles/verified-theme.ts
@@ -240,5 +240,15 @@ export const theme = createTheme({
         },
       },
     },
+    MuiTooltip: {
+      styleOverrides: {
+        tooltip: {
+          fontFamily: 'monospace!important',
+          '& pre': {
+            fontFamily: 'monospace!important',
+          },
+        },
+      },
+    },
   },
 });

--- a/app/validations/birthDate.schema.ts
+++ b/app/validations/birthDate.schema.ts
@@ -12,10 +12,12 @@ const validate = (value: string) => {
     59,
     999
   );
-  const valueDate = new Date(value);
+  // Safari doesn't allow date strings with hyphens
+  const formattedValue = value.replace(/-/g, '/');
+  const valueDate = new Date(formattedValue);
 
   if (valueDate >= minDate && valueDate <= maxDate) {
-    const date = Date.parse(String(new Date(value)));
+    const date = Date.parse(String(new Date(formattedValue)));
     return !isNaN(date);
   }
 


### PR DESCRIPTION
## Summary
Fixed personal info CTA button for safari that was not validating the birth date type `dd-mm-yyyy` but does `dd/mm/yyyy`. Also, updated the disabled status for the title, description and redirect url accordions when non-hosted option is selected. Also removed validity of empty type credential request but filtering out on submission.

[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->

## Changes
- small bug fixes

## Testing
Tested locally in brave and safari.

## Checklist

- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects