### PR TITLE
chore: add test id

### DIFF
--- a/app/components/OTPInput.tsx
+++ b/app/components/OTPInput.tsx
@@ -109,6 +109,7 @@ function OTPInputComponent(
   const inputProps: TextFieldProps = useMemo(
     () => ({
       inputProps: {
+        'data-testid': 'otp-input' as any,
         inputMode: 'numeric',
         maxLength: 1,
       },
@@ -217,7 +218,7 @@ function OTPInputComponent(
   );
 
   return (
-    <Box width='100%'>
+    <Box width='100%' data-testid='otp-input-container'>
       {/* Use input facade to update the value and listen to changes */}
       <TextField
         inputRef={inputRef}

--- a/app/features/customConfig/components/CustomizableDialog/components/DataFieldAccordion.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/components/DataFieldAccordion.tsx
@@ -110,6 +110,7 @@ export function DataFieldAccordion(props: DataFieldAccordionProps) {
         mt: 0,
         p: '8px !important',
       }}
+      data-testid='custom-demo-dialog-data-field-accordion'
     >
       <AccordionSummary
         onClick={() => setOpen((prev) => !prev)}

--- a/app/features/customConfig/components/CustomizableDialog/components/DataFieldAccordion.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/components/DataFieldAccordion.tsx
@@ -122,6 +122,7 @@ export function DataFieldAccordion(props: DataFieldAccordionProps) {
                 e.stopPropagation();
                 setModalOpen(true);
               }}
+              data-testid='custom-demo-dialog-data-field-delete-button'
             >
               <Delete
                 fontSize='small'

--- a/app/features/customConfig/components/CustomizableDialog/components/DataFieldDeleteModal.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/components/DataFieldDeleteModal.tsx
@@ -66,6 +66,7 @@ export function DataFieldDeleteModal({
           size='small'
           onClick={onClose}
           sx={buttonStyle}
+          data-testid='custom-demo-dialog-data-field-delete-cancel-button'
         >
           Don't Delete
         </OriginalButton>
@@ -74,6 +75,7 @@ export function DataFieldDeleteModal({
           size='small'
           onClick={onConfirm}
           sx={buttonStyle}
+          data-testid='custom-demo-dialog-data-field-delete-confirm-button'
         >
           Delete
         </OriginalButton>

--- a/app/features/customConfig/components/CustomizableDialog/components/DataFieldDescription.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/components/DataFieldDescription.tsx
@@ -55,6 +55,9 @@ export function DataFieldDescription() {
         color='success'
         size='small'
         className='original'
+        inputProps={{
+          'data-testid': 'custom-demo-dialog-data-field-description-input',
+        }}
       />
     </DataFieldSection>
   );

--- a/app/features/customConfig/components/CustomizableDialog/components/DataFieldMandatory.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/components/DataFieldMandatory.tsx
@@ -48,18 +48,33 @@ export function DataFieldMandatory() {
           title='Optional'
           description='Optional for the user to share'
           tip={MandatoryEnum.NO}
+          inputProps={
+            {
+              'data-testid': 'custom-demo-dialog-mandatory-no-radio',
+            } as any
+          }
         />
         <RadioOption
           value={MandatoryEnum.IF_AVAILABLE}
           title='Required if available'
           description='Required to share, if the user has it'
           tip={MandatoryEnum.IF_AVAILABLE}
+          inputProps={
+            {
+              'data-testid': 'custom-demo-dialog-mandatory-if_available-radio',
+            } as any
+          }
         />
         <RadioOption
           value={MandatoryEnum.YES}
           title='Required'
           description="Required — flow fails if user doesn't have it"
           tip={MandatoryEnum.YES}
+          inputProps={
+            {
+              'data-testid': 'custom-demo-dialog-mandatory-yes-radio',
+            } as any
+          }
         />
       </RadioGroup>
     </DataFieldSection>

--- a/app/features/customConfig/components/CustomizableDialog/components/DataFieldOptionType.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/components/DataFieldOptionType.tsx
@@ -76,6 +76,9 @@ export function DataFieldOptionType() {
             size='small'
             className='original'
             fullWidth
+            inputProps={{
+              'data-testid': 'custom-demo-dialog-data-field-type-input',
+            }}
           />
         )}
         disabled={(credentialRequestField?.level || 0) > 0 || schemas === null}

--- a/app/features/customConfig/components/CustomizableDialog/components/DataFieldSection.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/components/DataFieldSection.tsx
@@ -19,6 +19,7 @@ export function DataFieldSection(props: DataFieldSectionProps) {
         <Typography
           variant='body1'
           sx={{ fontSize: '16px', fontWeight: '700' }}
+          data-testid='custom-demo-dialog-data-field-title'
         >
           {title}
         </Typography>
@@ -33,6 +34,7 @@ export function DataFieldSection(props: DataFieldSectionProps) {
             fontSize: '12px',
             fontWeight: '400',
           }}
+          data-testid='custom-demo-dialog-data-field-description'
         >
           {description}
         </Typography>

--- a/app/features/customConfig/components/CustomizableDialog/components/DataFieldUserInput.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/components/DataFieldUserInput.tsx
@@ -45,12 +45,22 @@ export function DataFieldUserInput() {
           title='Yes'
           description='The user can add or edit data for the user to share'
           tip='true'
+          inputProps={
+            {
+              'data-testid': 'custom-demo-dialog-user-input-yes-radio',
+            } as any
+          }
         />
         <RadioOption
           value={false}
           title='No'
           description="The user can't add or edit data"
           tip='false'
+          inputProps={
+            {
+              'data-testid': 'custom-demo-dialog-user-input-no-radio',
+            } as any
+          }
         />
       </RadioGroup>
     </DataFieldSection>

--- a/app/features/customConfig/components/CustomizableDialog/components/DescriptionField.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/components/DescriptionField.tsx
@@ -27,6 +27,7 @@ export function DescriptionField() {
       sx={{
         opacity: isHosted.field.value ? 1 : 0.5,
       }}
+      data-testid='custom-demo-dialog-description-accordion'
     >
       <TextField
         {...field.field}

--- a/app/features/customConfig/components/CustomizableDialog/components/EnvironmentStep.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/components/EnvironmentStep.tsx
@@ -84,12 +84,22 @@ export function EnvironmentStep({
               title='Mock data (sandbox)'
               description='Random example data'
               tip='Sandbox'
+              inputProps={
+                {
+                  'data-testid': 'custom-demo-dialog-environment-mock-radio',
+                } as any
+              }
             />
             <RadioOption
               value='real'
               title='Real, verified data (production)'
               description='Like SSN, DOB, Address, Name'
               tip='Production'
+              inputProps={
+                {
+                  'data-testid': 'custom-demo-dialog-environment-real-radio',
+                } as any
+              }
             />
           </RadioGroup>
         </Stack>

--- a/app/features/customConfig/components/CustomizableDialog/components/HostedField.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/components/HostedField.tsx
@@ -30,6 +30,7 @@ export function HostedField() {
           py: 0.5,
         },
       }}
+      data-testid='custom-demo-dialog-hosted-accordion'
     >
       <RadioGroup
         value={isHosted.field.value}
@@ -53,12 +54,18 @@ export function HostedField() {
           title='Verified UI'
           description='Verified Inc. hosts the page'
           tip='true'
+          inputProps={
+            { 'data-testid': 'custom-demo-dialog-hosted-radio' } as any
+          }
         />
         <RadioOption
           value={false}
           title={`${brand.name} UI`}
           description={`${brand.name} hosts the page`}
           tip='false'
+          inputProps={
+            { 'data-testid': 'custom-demo-dialog-non-hosted-radio' } as any
+          }
         />
       </RadioGroup>
     </SectionAccordion>

--- a/app/features/customConfig/components/CustomizableDialog/components/RedirectUrlField.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/components/RedirectUrlField.tsx
@@ -23,6 +23,7 @@ export function RedirectUrlField() {
       sx={{
         opacity: isHosted.field.value ? 1 : 0.5,
       }}
+      data-testid='custom-demo-dialog-redirect-url-accordion'
     >
       <TextField
         {...field.field}

--- a/app/features/customConfig/components/CustomizableDialog/components/SectionAccordion.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/components/SectionAccordion.tsx
@@ -18,10 +18,18 @@ type SectionAccordionProps = {
   description?: string;
   tip?: ReactNode;
   sx?: SxProps;
+  'data-testid'?: string;
 };
 
 export function SectionAccordion(props: SectionAccordionProps) {
-  const { children, defaultExpanded, title, description, tip } = props;
+  const {
+    children,
+    defaultExpanded,
+    title,
+    description,
+    tip,
+    'data-testid': dataTestId,
+  } = props;
   const [expanded, setOpen] = useState(defaultExpanded || false);
 
   return (
@@ -37,6 +45,7 @@ export function SectionAccordion(props: SectionAccordionProps) {
         my: '0px !important',
         mt: 2,
       }}
+      data-testid={dataTestId}
     >
       <AccordionSummary
         onClick={() => setOpen((prev) => !prev)}

--- a/app/features/customConfig/components/CustomizableDialog/components/TitleField.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/components/TitleField.tsx
@@ -30,6 +30,7 @@ export function TitleField() {
           py: 0.5,
         },
       }}
+      data-testid='custom-demo-dialog-title-accordion'
     >
       <RadioGroup {...title.field}>
         <RadioOption

--- a/app/features/customConfig/components/CustomizableDialog/components/VerificationOptionsField.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/components/VerificationOptionsField.tsx
@@ -26,6 +26,7 @@ export function VerificationOptionsField() {
           py: 0.5,
         },
       }}
+      data-testid='custom-demo-dialog-verification-options-accordion'
     >
       <RadioGroup {...verificationOptions.field}>
         <RadioOption


### PR DESCRIPTION
## Summary
Add the testid attribute to elements on the page that interact with the customization dialog, allowing you to write better and more stable e2e tests. 

[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->

## Changes
- custom dialog components

## Testing
Tested locally.

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [ ] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects