### PR TITLE
fix: pass params input props

### DIFF
--- a/app/features/customConfig/components/CustomizableDialog/components/DataFieldOptionType.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/components/DataFieldOptionType.tsx
@@ -77,6 +77,7 @@ export function DataFieldOptionType() {
             className='original'
             fullWidth
             inputProps={{
+              ...params.inputProps,
               'data-testid': 'custom-demo-dialog-data-field-type-input',
             }}
           />


### PR DESCRIPTION
## Summary
Fix passing input props to the input component of auto-complete.

[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->

## Changes
- updated autocomplete component

## Testing
Tested locally.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects