### PR TITLE
feat: add restart demo and share demo buttons

### DIFF
--- a/app/components/OriginalButton.tsx
+++ b/app/components/OriginalButton.tsx
@@ -1,7 +1,10 @@
 import { useMemo } from 'react';
 import { Button, ButtonProps, SxProps, useTheme } from '@mui/material';
 
-export function OriginalButton({ children, ...props }: ButtonProps) {
+export function OriginalButton({
+  children,
+  ...props
+}: ButtonProps & { newVariant?: string }) {
   const theme = useTheme() as unknown as any;
   const defaultProps = theme.components.MuiButton.defaultProps;
   const sx: SxProps = useMemo(() => {
@@ -38,6 +41,15 @@ export function OriginalButton({ children, ...props }: ButtonProps) {
       }
     }
 
+    if (props.newVariant === 'gray') {
+      style = {
+        ...style,
+        backgroundColor: '#E0E0E0!important',
+        color: 'black !important',
+        borderColor: 'transparent',
+      };
+    }
+
     if (props.variant === 'text') {
       style = {
         ...style,
@@ -69,10 +81,12 @@ export function OriginalButton({ children, ...props }: ButtonProps) {
     return style;
   }, [
     defaultProps.sx,
+    props.color,
     props.disabled,
     props.size,
     props.sx,
     props.variant,
+    theme.palette.error.main,
     theme.palette.text.disabled,
   ]);
 

--- a/app/features/share/hooks/useShareDemo.ts
+++ b/app/features/share/hooks/useShareDemo.ts
@@ -1,0 +1,29 @@
+export function useShareDemo() {
+  const handleShareDemo = () => {
+    const currentUrl = new URL(window.location.href);
+    const url = new URL(window.location.origin);
+    const configState = currentUrl.searchParams.get('configState');
+    const secondaryEnvBrand = currentUrl.searchParams.get('secondaryEnvBrand');
+    const primaryEnvBrand = currentUrl.searchParams.get('primaryEnvBrand');
+
+    if (configState) {
+      url.searchParams.set('configState', configState);
+    }
+
+    if (secondaryEnvBrand) {
+      url.searchParams.set('secondaryEnvBrand', secondaryEnvBrand);
+    }
+
+    if (primaryEnvBrand) {
+      url.searchParams.set('primaryEnvBrand', primaryEnvBrand);
+    }
+
+    if ('share' in window.navigator) {
+      window.navigator.share({ url: url.toString() });
+    }
+  };
+
+  return {
+    handleShareDemo,
+  };
+}

--- a/app/routes/account.tsx
+++ b/app/routes/account.tsx
@@ -35,9 +35,9 @@ export default function Account() {
   const { credentials, credentialRequests, schemas, ...rest } = useLoaderData();
 
   const [searchParams] = useSearchParams();
-  const dashboardPageLink = useMemo(() => {
+  const verifieddPageLink = useMemo(() => {
     const searchParamsString = searchParams.toString();
-    return `/${searchParamsString ? `?${searchParamsString}` : ''}`;
+    return `/verified${searchParamsString ? `?${searchParamsString}` : ''}`;
   }, [searchParams]);
 
   return (
@@ -63,7 +63,7 @@ export default function Account() {
           credentials={credentials}
           schema={schemas}
         />
-        <Link to={dashboardPageLink}>
+        <Link to={verifieddPageLink}>
           <Button fullWidth>Go Back</Button>
         </Link>
       </Stack>

--- a/app/routes/verified.tsx
+++ b/app/routes/verified.tsx
@@ -1,5 +1,5 @@
-import { Button, Typography } from '@mui/material';
-import { Box } from '@mui/system';
+import { Box, Button, Typography } from '@mui/material';
+import { Refresh, Share } from '@mui/icons-material';
 import {
   ActionFunction,
   json,
@@ -14,6 +14,8 @@ import { VerifiedImage } from '~/components/VerifiedImage';
 import { useBrand } from '~/hooks/useBrand';
 import { logoutUseCase } from '~/features/logout/usecases/logoutUseCase';
 import { useFullName } from '~/hooks/useFullName';
+import { OriginalButton } from '~/components/OriginalButton';
+import { useShareDemo } from '~/features/share/hooks/useShareDemo';
 
 // The exported `action` function will be called when the route makes a POST request, i.e. when the form is submitted.
 export const action: ActionFunction = async ({ request }) => {
@@ -49,6 +51,7 @@ export default function Verified() {
   const brand = useBrand();
   const { session } = useLoaderData<typeof loader>();
   const name = useFullName(session);
+  const { handleShareDemo } = useShareDemo();
 
   const solidButtonProps = {
     sx: {
@@ -57,27 +60,6 @@ export default function Verified() {
       px: 3.5,
       fontSize: '1.4rem',
     },
-  };
-
-  const renderGoHomeButton = () => {
-    const buttonProps = {
-      ...solidButtonProps,
-      children: 'Go to Home',
-    };
-
-    if (brand.homepageUrl) {
-      return (
-        <Button href={brand.homepageUrl} {...buttonProps}>
-          Go to Home
-        </Button>
-      );
-    }
-
-    return (
-      <Form method='post'>
-        <Button {...buttonProps}>Go to Home</Button>
-      </Form>
-    );
   };
 
   return (
@@ -94,10 +76,9 @@ export default function Verified() {
       >
         You're verified and signed up.
       </Typography>
-      {renderGoHomeButton()}
       <Form method='post'>
         <input name='action' value='account' readOnly hidden />
-        <Button {...solidButtonProps}>See Account</Button>
+        <Button {...solidButtonProps}>My Account</Button>
       </Form>
       <Form method='post'>
         <input name='action' value='logout' readOnly hidden />
@@ -118,6 +99,39 @@ export default function Verified() {
       <Box mt={6}>
         <VerifiedImage theme={brand.theme} sx={{ maxWidth: 267 }} />
       </Box>
+      <Form method='post'>
+        <input name='action' value='logout' readOnly hidden />
+        <OriginalButton
+          newVariant='gray'
+          size='small'
+          startIcon={<Refresh />}
+          sx={{
+            alignSelf: 'center',
+            py: 1,
+            px: 2,
+            fontSize: '1rem',
+            mt: 2,
+          }}
+        >
+          Restart Demo
+        </OriginalButton>
+      </Form>
+      <OriginalButton
+        onClick={handleShareDemo}
+        type='button'
+        variant='contained'
+        size='small'
+        startIcon={<Share />}
+        sx={{
+          alignSelf: 'center',
+          py: 1,
+          px: 2,
+          fontSize: '1rem',
+          mt: 2,
+        }}
+      >
+        Share Demo
+      </OriginalButton>
     </Box>
   );
 }


### PR DESCRIPTION
## Summary
Adds two button features, one is the ability to restart the demo, and the other is the ability to share the demo. And minor layout changes.

[Ticket](https://trello.com/c/fOKWAZXE/6920-demo-layout-changes)
<!---
Link to the Trello ticket for this work.
--->

## Changes
- updated verified page
- updated account page

## Testing
Tested locally.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects