### PR TITLE
feat: copy to clipboard when share api is not available for browser

### DIFF
--- a/app/features/share/hooks/useShareDemo.ts
+++ b/app/features/share/hooks/useShareDemo.ts
@@ -20,6 +20,10 @@ export function useShareDemo() {
 
     if ('share' in window.navigator) {
       window.navigator.share({ url: url.toString() });
+    } else {
+      // Fallback for browsers that don't support Web Share API.
+      // Copy the URL to clipboard.
+      navigator.clipboard.writeText(url.toString());
     }
   };
 


### PR DESCRIPTION
## Summary
Handle copy to clipboard when share button is pressed if the navigator does not support web share api.

[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->

## Changes
<!---
List all non-trivial changes included in this PR. Bullet points are fine or the individual commits that make up this PR.
--->

## Testing
<!---
How did you test your changes? How might someone else test them?
--->

## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [ ] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects