### PR TITLE
chore: rename signin to login and add access title

### DIFF
--- a/app/features/customConfig/components/CustomizableDialog/components/TitleField.tsx
+++ b/app/features/customConfig/components/CustomizableDialog/components/TitleField.tsx
@@ -42,10 +42,10 @@ export function TitleField() {
           disabled={!isHosted.field.value}
         />
         <RadioOption
-          value={OneClickContentTitle.Signin}
-          title={OneClickContentTitle.Signin}
-          description='"1-Click Signin"'
-          tip='Signin'
+          value={OneClickContentTitle.Login}
+          title={OneClickContentTitle.Login}
+          description='"1-Click Login"'
+          tip='Login'
           disabled={!isHosted.field.value}
         />
         <RadioOption
@@ -60,6 +60,13 @@ export function TitleField() {
           title={OneClickContentTitle.Apply}
           description='"1-Click Apply"'
           tip='Apply'
+          disabled={!isHosted.field.value}
+        />
+        <RadioOption
+          value={OneClickContentTitle.Access}
+          title={OneClickContentTitle.Access}
+          description='"1-Click Access"'
+          tip='Access'
           disabled={!isHosted.field.value}
         />
       </RadioGroup>

--- a/app/features/customConfig/types.ts
+++ b/app/features/customConfig/types.ts
@@ -5,9 +5,10 @@ export enum OneClickEnvironment {
 
 export enum OneClickContentTitle {
   Signup = 'Signup',
-  Signin = 'Signin',
+  Login = 'Login',
   Verify = 'Verify',
   Apply = 'Apply',
+  Access = 'Access',
 }
 
 export enum OneClickContentVerificationOptions {


### PR DESCRIPTION
## Summary
Renames `Signin` title to `Login`, and add `Access` title to the custom configuration in `1-Click Language`.

[Ticket](<!-- link to ticket -->)
<!---
Link to the Trello ticket for this work.
--->

## Changes
- updated title options

## Testing
Tested locally.

## Checklist

- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas _to a borderline excessive amount_
- [ ] I have made any relevant corresponding changes to the documentation including the project readme.
- [x] I have run and tested the changes locally
- [ ] If it is a core feature, I have added an appropriate amount of unit tests.
- [ ] Any dependent changes have been merged and published in upstream projects